### PR TITLE
Bug fix on checking boxes when pressing in the box.

### DIFF
--- a/script.js
+++ b/script.js
@@ -9,8 +9,7 @@ document.addEventListener('DOMContentLoaded', function () {
                         <input type="checkbox" id="task-${task.id}" ${task.completed ? 'checked' : ''} onchange="toggleTaskCompletion(${task.id})">
                         <label for="task-${task.id}" class="${task.completed ? 'completed' : ''}">${task.title}</label>
                         <div class="box" onclick="toggleSize(this)">
-                          <label for="task-${task.id}" class="${task.completed ? 'completed' : ''}">
-                          <h2>${task.title}</h2></label>
+                          <h2>${task.title}</h2>
                           <div class="content">
                             <p>Time started: ${task.start}</p>
                             <p>Deadline: ${task.due}</p>


### PR DESCRIPTION
There was a bug where pressing the title of the task in the box could check the task off. This would be an issue for users who want to expand the box but not check off the task. I fixed it so you can only check off the task using the checkbox. Close #8.